### PR TITLE
Submission

### DIFF
--- a/infra_setup/init.sql
+++ b/infra_setup/init.sql
@@ -3,6 +3,34 @@
 CREATE SCHEMA IF NOT EXISTS ALT_SCHOOL;
 
 
+-- setup the events table following the examle provided
+create table ALT_SCHOOL.EVENTS
+    (
+        event_id bigint PRIMARY KEY,
+        customer_id uuid,
+        event_data JSONB NOT NULL,
+        event_timestamp timestamp NOT NULL
+    );
+
+-- TODO: provide the command to copy ALT_SCHOOL.EVENTS data into POSTGRES
+
+
+CREATE TABLE IF NOT EXISTS ALT_SCHOOL.CUSTOMERS
+(
+    customer_id uuid PRIMARY KEY,
+    device_id uuid NOT NULL,
+    location varchar,
+    currency varchar
+);
+
+create table ALT_SCHOOL.ORDERS
+    (
+        order_id uuid not null primary key,
+        customer_id uuid,
+        status varchar,
+        checked_out_at timestamp
+    );
+
 -- create and populate tables
 create table if not exists ALT_SCHOOL.PRODUCTS
 (
@@ -11,9 +39,26 @@ create table if not exists ALT_SCHOOL.PRODUCTS
     price numeric(10, 2) not null
 );
 
+-- provide the command to copy ALT_SCHOOL.LINE_ITEMS data into POSTGRES
+create table ALT_SCHOOL.LINE_ITEMS
+    (
+        line_item_id BIGINT PRIMARY KEY,
+        order_id uuid,
+        item_id serial,
+        quantity BIGINT
+    );
 
-COPY ALT_SCHOOL.PRODUCTS (id, name, price)
-FROM '/data/products.csv' DELIMITER ',' CSV HEADER;
+
+COPY ALT_SCHOOL.EVENTS (event_id, customer_id, event_data, event_timestamp) FROM '/data/events.csv' DELIMITER ',' CSV HEADER;
+
+COPY ALT_SCHOOL.CUSTOMERS (customer_id, device_id, location, currency) FROM '/data/customers.csv' DELIMITER ',' CSV HEADER;
+
+COPY ALT_SCHOOL.ORDERS (order_id, customer_id, status, checked_out_at) FROM '/data/orders.csv' DELIMITER ',' CSV HEADER;
+
+COPY ALT_SCHOOL.PRODUCTS (id, name, price) FROM '/data/products.csv' DELIMITER ',' CSV HEADER;
+
+COPY ALT_SCHOOL.LINE_ITEMS (line_item_id, order_id, item_id, quantity) FROM '/data/line_items.csv' DELIMITER ',' CSV HEADER;
+
 
 -- setup customers table following the example above
 
@@ -22,39 +67,4 @@ FROM '/data/products.csv' DELIMITER ',' CSV HEADER;
 -- TODO: provide the command to copy the customers data in the /data folder into ALT_SCHOOL.CUSTOMERS
 
 
-
--- TODO: complete the table DDL statement
-create table if not exists ALT_SCHOOL.ORDERS
-(
-    order_id uuid not null primary key,
-    -- provide the other fields
-);
-
-
 -- provide the command to copy orders data into POSTGRES
-
-
-create table if not exists ALT_SCHOOL.LINE_ITEMS
-(
-    line_item_id serial primary key,
-    -- provide the remaining fields
-);
-
-
--- provide the command to copy ALT_SCHOOL.LINE_ITEMS data into POSTGRES
-
-
--- setup the events table following the examle provided
-create table if not exists ALT_SCHOOL.EVENTS
-(
-    -- TODO: PROVIDE THE FIELDS
-);
-
--- TODO: provide the command to copy ALT_SCHOOL.EVENTS data into POSTGRES
-
-
-
-
-
-
-

--- a/questions/answers.sql
+++ b/questions/answers.sql
@@ -3,7 +3,8 @@
 -- 
 
 WITH checkouts AS (
-	-- filter rows with successful checkouts
+	-- CTE1 ->> checkouts: 
+    -- filter rows with successful checkouts identified by custmer_id
     SELECT * 
     FROM alt_school.events
     WHERE customer_id IN (
@@ -13,6 +14,7 @@ WITH checkouts AS (
     )
 ),
 removed_items AS (
+    -- CTE2 ->> removed_items
 	-- filter rows with items removed from cart after adding to the cart
     SELECT event_id, customer_id, event_data, CONCAT(customer_id, '_', event_data->>'item_id') AS ce 
     FROM alt_school.events
@@ -28,13 +30,18 @@ removed_items AS (
     )
 ),
 checker as (
-	-- table with only successful checkouts and 
+    -- CTE3 ->> checker
+	-- table with only items that were added to the cart, not removed and made it successful checkouts
 	SELECT * 
 	FROM checkouts
 	WHERE event_id NOT IN (
 		SELECT event_id FROM removed_items
 	)
 )
+
+-- solution query:
+-- product_id, product_name and num_times_in_successful_orders
+-- from events, products table joining on (item_id and product_id)
 
 SELECT 
     c.event_data->>'item_id' AS product_id,
@@ -44,7 +51,7 @@ FROM
     checker AS c
 JOIN 
     alt_school.products AS p ON c.event_data->>'item_id' = CAST(p.id AS TEXT)
---                                                    ^^^^^^^^^^^^^^^^^^^^^^
+--                                                    
 WHERE 
     c.event_data->>'event_type' = 'add_to_cart'
 GROUP BY 
@@ -60,7 +67,8 @@ LIMIT 1;
 -- 
 
 WITH checkouts AS (
-	-- filter rows with successful checkouts
+	-- CTE1 ->> checkouts: 
+    -- filter rows with successful checkouts identified by custmer_id
     SELECT * 
     FROM alt_school.events
     WHERE customer_id IN (
@@ -70,7 +78,8 @@ WITH checkouts AS (
     )
 ),
 removed_items AS (
-	-- filter rows with items removed from cart after adding to the cart
+	-- CTE2 ->> removed_items
+    -- filter rows with items removed from cart after adding to the cart
     SELECT event_id, customer_id, event_data, CONCAT(customer_id, '_', event_data->>'item_id') AS ce 
     FROM alt_school.events
     WHERE CONCAT(customer_id, '_', event_data->>'item_id') IN (
@@ -85,7 +94,8 @@ removed_items AS (
     )
 ),
 checker as (
-	-- table with only successful checkouts and 
+	-- CTE3 ->> checker
+    -- table with only items that were added to the cart, and made it successful checkouts 
 	SELECT * 
 	FROM checkouts
 	WHERE event_id NOT IN (
@@ -93,6 +103,8 @@ checker as (
 	)
 )
 
+-- solution query:
+-- 
 
 SELECT 
     c1.customer_id,
@@ -118,7 +130,8 @@ LIMIT 5;
 
 
 WITH checkouts AS (
-	-- filter rows with successful checkouts
+	-- CTE1 ->> checkouts: 
+    -- filter rows with successful checkouts identified by custmer_id
     SELECT * 
     FROM alt_school.events
     WHERE customer_id IN (
@@ -128,7 +141,8 @@ WITH checkouts AS (
     )
 ),
 removed_items AS (
-	-- filter rows with items that were added and removed from the cart
+	-- CTE2 ->> removed_items
+    -- filter rows with items removed from cart after adding to the cart
     SELECT event_id, customer_id, event_data, CONCAT(customer_id, '_', event_data->>'item_id') AS ce 
     FROM alt_school.events
     WHERE CONCAT(customer_id, '_', event_data->>'item_id') IN (
@@ -143,7 +157,8 @@ removed_items AS (
     )
 ),
 checker as (
-	-- table with only successful checkouts and 
+	-- CTE3 ->> checker
+    -- table with only items that were added to the cart, not removed and made it successful checkouts
 	SELECT * 
 	FROM checkouts
 	WHERE event_id NOT IN (

--- a/questions/answers.sql
+++ b/questions/answers.sql
@@ -1,6 +1,9 @@
 
 -- part 2.a.i: most ordered item based on the number of times it appears in an order cart that checked out successfully?
--- 
+
+--  product_id |    product_name    | num_times_in_successful_orders 
+--  -----------+--------------------+--------------------------------
+--  3          | Sony PlayStation 5 |                           1172
 
 WITH checkouts AS (
 	-- CTE1 ->> checkouts: 
@@ -64,7 +67,14 @@ LIMIT 1;
 
 
 -- part 2.a.ii: top five spenders
--- 
+
+--              customer_id              |  location   | total_spend 
+-- --------------------------------------+-------------+-------------
+--  c9eca26c-dfc4-4569-b404-ace1f3c27c2c | France      |    34935.70
+--  662af3bb-cd98-42b8-a299-6b42c23821e6 | Singapore   |    33831.78
+--  bf3e38e6-29c9-40c0-97a2-3ceaa7d305ad | Senegal     |    31525.73
+--  3c8e3261-bb06-4452-9342-11850addf518 | Switzerland |    31449.58
+--  f2e8a54d-6437-43ef-822c-74af0addcca4 | Liberia     |    30999.77
 
 WITH checkouts AS (
 	-- CTE1 ->> checkouts: 
@@ -128,6 +138,9 @@ LIMIT 5;
 
 -- part2.b.i: the most common location (country) where successful checkouts occurred.
 
+-- location | checkout_count 
+-- ---------+----------------
+-- Korea    |             17
 
 WITH checkouts AS (
 	-- CTE1 ->> checkouts: 
@@ -185,9 +198,29 @@ LIMIT 1;
 
 -- part 2.b.ii : customers who abandoned their carts and count the number of events (excluding visits) that occurred before the abandonment.
 
+--              customer_id              | num_events 
+--  -------------------------------------+------------
+--  1c2b1a0d-4627-42cb-a55a-24c7c92611b0 |         22
+--  713fe25b-a6c1-4978-9a56-2a5f711137d1 |         22
+--  82ae4c93-06a8-4530-9865-d06676acfb6f |         22
+--  3a09f477-dbee-4a17-9ef0-36f6bbd2e1dc |         22
+--  eb7dcb88-073d-403e-bdd4-1e5725fe2338 |         22
+--  8afb120e-84a2-4d64-afc5-18891385d3b3 |         22
+--  b1e5d31e-1feb-41cf-9a63-968c70c33744 |         22
+--  70676244-3cd0-40f0-a749-8a406059e70c |         22
+--  b4ee8d72-9064-4372-85c7-7ae091a0572c |         22
+--  f0b1a808-7def-4d7f-b2cb-723e92797f3f |         22
+--  2519a6f0-4287-40b5-a0eb-c994bace8543 |         22
+--  eeeea458-d704-4ef9-b7e6-618d2a8c47ed |         21
+--  7105dba6-13c9-46f1-947f-9b8c246d14a5 |         21
+--  a6a41da2-3e3c-4ef3-99e3-41e4777581a1 |         21
+--  64af4631-72c1-4388-ab42-38ebab1767ca |         21
+--    ---   - -- - -- - -- -  ---        |         --
+--                  < CONTD >            |  < CONTD >
+
 with sheet1 as (
 	-- this query selects all event types other than visits from abandoned carts.
-	-- here, we have an abandoned cart as a cart that does not make  asuccessful checkout.
+	-- here, we have an abandoned cart as a cart that does not make a successful checkout.
 	select * from alt_school.events
 		where customer_id not in (
 			select customer_id from alt_school.events where event_data->>'status'='success' or event_data ->> 'status' = 'failed'
@@ -203,8 +236,12 @@ order by num_events desc;
 
 --part 2.b.iii
 
+-- average_visits 
+-- ---------------
+--           4.47
+
 with visit_per_customer as (
-	---this subquery selects all visits from successful checkouts
+	---this subquery selects only visits from successful checkouts
 	select distinct customer_id, count(customer_id) as num_visits
 	from alt_school.events
 	where event_data->>'event_type'='visit' and customer_id in (
@@ -213,5 +250,7 @@ with visit_per_customer as (
 	group by customer_id
 	order by num_visits desc
 )
-select ROUND(AVG(num_visits), 2) 
+
+-- average visit per customer
+select ROUND(AVG(num_visits), 2) as average_visits
 from visit_per_customer;

--- a/questions/answers.sql
+++ b/questions/answers.sql
@@ -1,0 +1,202 @@
+
+-- part 2.a.i: most ordered item based on the number of times it appears in an order cart that checked out successfully?
+-- 
+
+WITH checkouts AS (
+	-- filter rows with successful checkouts
+    SELECT * 
+    FROM alt_school.events
+    WHERE customer_id IN (
+        SELECT customer_id 
+        FROM alt_school.events AS e 
+        WHERE e.event_data->>'status' = 'success'
+    )
+),
+removed_items AS (
+	-- filter rows with items removed from cart after adding to the cart
+    SELECT event_id, customer_id, event_data, CONCAT(customer_id, '_', event_data->>'item_id') AS ce 
+    FROM alt_school.events
+    WHERE CONCAT(customer_id, '_', event_data->>'item_id') IN (
+        SELECT CONCAT(customer_id, '_', event_data->>'item_id') 
+        FROM alt_school.events 
+        WHERE event_data->>'event_type' = 'remove_from_cart'
+    )
+    AND CONCAT(customer_id, '_', event_data->>'item_id') IN (
+        SELECT CONCAT(customer_id, '_', event_data->>'item_id') 
+        FROM alt_school.events 
+        WHERE event_data->>'event_type' = 'add_to_cart'
+    )
+),
+checker as (
+	-- table with only successful checkouts and 
+	SELECT * 
+	FROM checkouts
+	WHERE event_id NOT IN (
+		SELECT event_id FROM removed_items
+	)
+)
+
+SELECT 
+    c.event_data->>'item_id' AS product_id,
+    p.name as product_name,
+    SUM((c.event_data->>'quantity')::INT) AS num_times_in_successful_orders
+FROM 
+    checker AS c
+JOIN 
+    alt_school.products AS p ON c.event_data->>'item_id' = CAST(p.id AS TEXT)
+--                                                    ^^^^^^^^^^^^^^^^^^^^^^
+WHERE 
+    c.event_data->>'event_type' = 'add_to_cart'
+GROUP BY 
+    c.event_data->>'item_id', p.name
+ORDER BY 
+    num_times_in_successful_orders DESC
+LIMIT 1;
+
+
+
+
+-- part 2.a.ii: top five spenders
+-- 
+
+WITH checkouts AS (
+	-- filter rows with successful checkouts
+    SELECT * 
+    FROM alt_school.events
+    WHERE customer_id IN (
+        SELECT customer_id 
+        FROM alt_school.events AS e 
+        WHERE e.event_data->>'status' = 'success'
+    )
+),
+removed_items AS (
+	-- filter rows with items removed from cart after adding to the cart
+    SELECT event_id, customer_id, event_data, CONCAT(customer_id, '_', event_data->>'item_id') AS ce 
+    FROM alt_school.events
+    WHERE CONCAT(customer_id, '_', event_data->>'item_id') IN (
+        SELECT CONCAT(customer_id, '_', event_data->>'item_id') 
+        FROM alt_school.events 
+        WHERE event_data->>'event_type' = 'remove_from_cart'
+    )
+    AND CONCAT(customer_id, '_', event_data->>'item_id') IN (
+        SELECT CONCAT(customer_id, '_', event_data->>'item_id') 
+        FROM alt_school.events 
+        WHERE event_data->>'event_type' = 'add_to_cart'
+    )
+),
+checker as (
+	-- table with only successful checkouts and 
+	SELECT * 
+	FROM checkouts
+	WHERE event_id NOT IN (
+		SELECT event_id FROM removed_items
+	)
+)
+
+
+SELECT 
+    c1.customer_id,
+    c2.location,
+    SUM((p.price * (c1.event_data->>'quantity')::NUMERIC)) AS total_spend
+FROM 
+    checker AS c1
+JOIN 
+    alt_school.products AS p ON c1.event_data->>'item_id' = CAST(p.id AS TEXT)
+JOIN 
+    alt_school.customers AS c2 ON c1.customer_id = c2.customer_id
+WHERE 
+    c1.event_data->>'event_type' = 'add_to_cart'
+GROUP BY 
+    c1.customer_id, c2.location
+ORDER BY 
+    total_spend DESC
+LIMIT 5;
+
+
+
+-- part2.b.i: the most common location (country) where successful checkouts occurred.
+
+
+WITH checkouts AS (
+	-- filter rows with successful checkouts
+    SELECT * 
+    FROM alt_school.events
+    WHERE customer_id IN (
+        SELECT customer_id 
+        FROM alt_school.events AS e 
+        WHERE e.event_data->>'status' = 'success'
+    )
+),
+removed_items AS (
+	-- filter rows with items that were added and removed from the cart
+    SELECT event_id, customer_id, event_data, CONCAT(customer_id, '_', event_data->>'item_id') AS ce 
+    FROM alt_school.events
+    WHERE CONCAT(customer_id, '_', event_data->>'item_id') IN (
+        SELECT CONCAT(customer_id, '_', event_data->>'item_id') 
+        FROM alt_school.events 
+        WHERE event_data->>'event_type' = 'remove_from_cart'
+    )
+    AND CONCAT(customer_id, '_', event_data->>'item_id') IN (
+        SELECT CONCAT(customer_id, '_', event_data->>'item_id') 
+        FROM alt_school.events 
+        WHERE event_data->>'event_type' = 'add_to_cart'
+    )
+),
+checker as (
+	-- table with only successful checkouts and 
+	SELECT * 
+	FROM checkouts
+	WHERE event_id NOT IN (
+		SELECT event_id FROM removed_items
+	)
+)
+
+SELECT 
+    c2.location,
+    COUNT(DISTINCT c1.customer_id) AS checkout_count
+FROM 
+    checker AS c1 
+JOIN 
+    alt_school.customers AS c2 ON c1.customer_id = c2.customer_id  
+WHERE 
+    event_data->>'status' = 'success' 
+GROUP BY 
+    c2.location
+ORDER BY 
+    checkout_count DESC
+LIMIT 1;
+
+
+
+-- part 2.b.ii : customers who abandoned their carts and count the number of events (excluding visits) that occurred before the abandonment.
+
+with sheet1 as (
+	-- this query selects all event types other than visits from abandoned carts.
+	-- here, we have an abandoned cart as a cart that does not make  asuccessful checkout.
+	select * from alt_school.events
+		where customer_id not in (
+			select customer_id from alt_school.events where event_data->>'status'='success' or event_data ->> 'status' = 'failed'
+		)
+		and
+		event_data ->> 'event_type'!='visit' and event_data->>'event_type'!='checkout'
+)
+select customer_id, count(event_data->>'event_type') as num_events  from sheet1
+group by customer_id
+order by num_events desc;
+
+
+
+--part 2.b.iii
+
+with visit_per_customer as (
+	---this subquery selects all visits from successful checkouts
+	select distinct customer_id, count(customer_id) as num_visits
+	from alt_school.events
+	where event_data->>'event_type'='visit' and customer_id in (
+		select customer_id from alt_school.events where event_data->>'status'='success'
+	)
+	group by customer_id
+	order by num_visits desc
+)
+select ROUND(AVG(num_visits), 2) 
+from visit_per_customer;


### PR DESCRIPTION
# Submission
## part 2.a. i. most ordered item based on the number of times it appears in an order cart that checked out successfully?
            
### 1. Common Table Expressions (CTEs):
- Three CTEs (`checkouts`, `removed_items`, and `checker`) are defined to filter the events table and isolate successful checkouts without removed items.
### 2. Main Query:
- The main query retrieves the product ID, product name, and the total number of times each product was added to successful checkouts.
- It joins the `checker` CTE with the `alt_school.products` table based on the item ID.
- Filters the rows where the event type is `add_to_cart`.
- Groups the results by product ID and product name.
- Orders the results by the total number of times each product was added to successful checkouts in descending order.
- Limits the result to one row, indicating the most frequently purchased product.

### Result.
product_id |    product_name    | num_times_in_successful_orders 
--- | --- | ---
3 | Sony PlayStation 5 | 1172

## Part 2.a.ii. Top five spenders

### 1.  Common Table Expressions (CTEs):
Three CTEs (`checkouts`, `removed_items`, and `checker`) are defined to filter the events table and isolate successful checkouts without removed items.
### 2. Main Query:
The main query retrieves the customer ID, location, and the total amount spent by each customer.
It joins the `checker` CTE with the `alt_school.products` table and the `alt_school.customers` table based on customer ID and item ID.
Filters the rows where the event type is 'add_to_cart'.
Groups the results by customer ID and location.
Orders the results by the total amount spent by each customer in descending order.
Limits the result to the top five spenders.

### Result.
customer_id | location | total_spend 
--- | --- |---
c9eca26c-dfc4-4569-b404-ace1f3c27c2c | France      |    34935.70
662af3bb-cd98-42b8-a299-6b42c23821e6 | Singapore   |    33831.78
bf3e38e6-29c9-40c0-97a2-3ceaa7d305ad | Senegal     |    31525.73
3c8e3261-bb06-4452-9342-11850addf518 | Switzerland |    31449.58
f2e8a54d-6437-43ef-822c-74af0addcca4 | Liberia     |    30999.77

## part 2.b.i. **the most common location** (country) where successful checkouts occurred.

### 1.  Common Table Expressions (CTEs):
- Three CTEs (`checkouts`, `removed_items`, and `checker`) are defined to filter the events table and isolate successful checkouts without removed items.
### 2. Main Query:
- The main query retrieves the location and the count of unique customers who successfully completed their purchases in each location.
- It joins the checker CTE with the alt_school.customers table based on customer ID.
- Filters the rows where the event status is 'success'.
- Groups the results by location.
- Orders the results by the count of successful checkouts in each location in descending order.
- Limits the result to one row, indicating the most common location.

### Result.
location | checkout_count 
--- | ---
Korea | 17

## part 2.b.ii. the customers who abandoned their carts and count the number of events (excluding visits) that occurred before the abandonment.

### 1. Common Table Expression (CTE):
- A CTE named `sheet1` is defined to select all event types other than visits from abandoned carts. Abandoned carts are identified as those that do not result in a successful checkout.
### 2. Main Query:
- The main query selects the `customer_id` and counts the number of events (excluding visits) for each customer from the `sheet1` CTE.
- It groups the results by `customer_id` and orders them by the number of events in descending order.

### Result.
|             customer_id              | num_events |
|--------------------------------------|------------|
| 1c2b1a0d-4627-42cb-a55a-24c7c92611b0 |         22 |
| 713fe25b-a6c1-4978-9a56-2a5f711137d1 |         22 |
| 82ae4c93-06a8-4530-9865-d06676acfb6f |         22 |
| 3a09f477-dbee-4a17-9ef0-36f6bbd2e1dc |         22 |
| eb7dcb88-073d-403e-bdd4-1e5725fe2338 |         22 |
| 8afb120e-84a2-4d64-afc5-18891385d3b3 |         22 |
| b1e5d31e-1feb-41cf-9a63-968c70c33744 |         22 |
| 70676244-3cd0-40f0-a749-8a406059e70c |         22 |
| b4ee8d72-9064-4372-85c7-7ae091a0572c |         22 |
| f0b1a808-7def-4d7f-b2cb-723e92797f3f |         22 |
| 2519a6f0-4287-40b5-a0eb-c994bace8543 |         22 |
| eeeea458-d704-4ef9-b7e6-618d2a8c47ed |         21 |
| 7105dba6-13c9-46f1-947f-9b8c246d14a5 |         21 |
| a6a41da2-3e3c-4ef3-99e3-41e4777581a1 |         21 |
| 64af4631-72c1-4388-ab42-38ebab1767ca |         21 |
|          ... - ... - ... - ...       |      ...   |


## part 2.b.iii. average number of visits per customer, considering only customers who completed a checkout!

### 1. Common Table Expression (CTE):
- A CTE named `visit_per_customer` is defined to select only visits from successful checkouts.
- It counts the number of distinct visits for each customer who completed a successful checkout.
- The results are grouped by `customer_id` and ordered by the number of visits in descending order.
### 2. Main Query:
- The main query calculates the average number of visits per customer.
- It uses the `visit_per_customer` CTE to calculate the average and rounds the result to two decimal places.

### Result.
| average_visits |
| --- |
| 4.47 |